### PR TITLE
 fix  a typo error  in  fibo_speed.rst 

### DIFF
--- a/doc/source/fibo_speed.rst
+++ b/doc/source/fibo_speed.rst
@@ -189,7 +189,7 @@ So far we have looked at pushing code into Cython/C to get a performance gain ho
         try:
             val = cache[n]
         except KeyError:
-            val = fib(n-2) + fib(n-1)
+            val = fib_cached(n-2,cache) + fib_cached(n-1,cache)
             cache[n] = val
         return val
 


### PR DESCRIPTION
def fib_cached(n, cache={}):
    if n < 2:
        return n
    try:
        val = cache[n]
    except KeyError:
        val = fib(n-2) + fib(n-1)
        cache[n] = val
    return val

Maybe there is a typo error  in  function body :
val = fib(n-2) + fib(n-1)
should be like this:
val = fib_cached(n-2,cache) + fib_cached(n-1,cache)